### PR TITLE
Added custom URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 composer require wdelfuego/nova-calendar
 ```
 
+### Publishing the config file
+```sh
+php artisan vendor:publish --provider="Wdelfuego\NovaCalendar\ToolServiceProvider" --tag="config"
+```
+
 # License summary
 Anyone can use and modify this package in any way they want, including commercially, as long as the commercial use is a) creating implemented calendar views and/or b) using the implemented calendar views.
 Basically the only condition is that you can't sublicense the package or embed it in a framework (unless you do so under the AGPLv3 license).

--- a/config/nova-calendar.php
+++ b/config/nova-calendar.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    /*
+     * Custom URI for Nova Calendar
+     */
+    'uri' => 'wdelfuego/nova-calendar',
+];

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -49,6 +49,10 @@ class ToolServiceProvider extends ServiceProvider
                 CreateDefaultCalendarDataProvider::class,
             ]);
         }
+
+        $this->publishes([
+            __DIR__.'/../config/nova-calendar.php' => config_path('nova-calendar.php'),
+        ], 'config');
     }
 
     /**
@@ -62,7 +66,7 @@ class ToolServiceProvider extends ServiceProvider
             return;
         }
 
-        Nova::router(['nova', Authorize::class], 'wdelfuego/nova-calendar')
+        Nova::router(['nova', Authorize::class], config('nova-calendar.uri', 'wdelfuego/nova-calendar'))
             ->group(__DIR__.'/../routes/inertia.php');
 
         Route::middleware(['nova', Authorize::class])


### PR DESCRIPTION
This PR allow you to customize the URI of the tool by publishing the new config file.

Added a default value to fallback to `wdelfuego/nova-calendar` for non-breaking change.