### PR TITLE
Added the ability to customize the page title via a configuration option

### DIFF
--- a/config/nova-calendar.php
+++ b/config/nova-calendar.php
@@ -20,4 +20,5 @@ return [
      * Custom URI for Nova Calendar
      */
     'uri' => 'wdelfuego/nova-calendar',
+    'title' => 'Nova Calendar',
 ];

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -116,6 +116,9 @@ The following options are currently supported:
 	
     If you change the URI in an existing installation that doesn't use Nova's default main menu, make sure to update the menu you generate in the `boot()` method of your `NovaServiceProvider` to be as shown under step 4 above, so it will automatically respect the configured option from now on.
 
+- `title` - The title of the calendar page (the one that appears on the browser tab)
+
+    Default value is `"Nova Calendar"`, but you can customize it to you liking.
 ---
 
 [⬅️ Back to Documentation overview](/nova-calendar)

--- a/resources/js/pages/Tool.vue
+++ b/resources/js/pages/Tool.vue
@@ -14,7 +14,7 @@
  
 <template>
   <div>
-    <Head title="Nova Calendar" />
+    <Head :title="pageTitle" />
 
     <div id="nc-control">
     
@@ -180,7 +180,15 @@ export default {
         return this.styles.default;
       }
     }
-  
+
+  },
+
+  props: {
+    pageTitle: {
+      type: String,
+      required: false,
+      default: 'Nova Calendar',
+    },
   },
 
   data () {

--- a/routes/inertia.php
+++ b/routes/inertia.php
@@ -30,5 +30,7 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 */
 
 Route::get('/', function (NovaRequest $request) {
-    return inertia('NovaCalendar');
+    return inertia('NovaCalendar', [
+        'pageTitle' => config('nova-calendar.title', 'Nova Calendar'),
+    ]);
 });


### PR DESCRIPTION
Just to be able to change the currently hard coded page title (`"Nova Calendar"`) to another value.

I added the config option `nova-calendar.title`, where users can change the default value. If no value is provided in the config file, the default one is maintained (`"Nova Calendar"`).

Also added the new option in the corresponding section in the docs.