### PR TITLE
Adds compatibility for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/support": "^9.0",
+        "illuminate/support": "^8.0|^9.0",
         "laravel/nova": "^4.2.4",
         "wdelfuego/nova-datetime": "^1.0.1"
     },


### PR DESCRIPTION
This tiny change to the `composer.json` file adds compatibility to Laravel 8.

The requirements do not mention it but because of the inclusion of `"illuminate/support": "^9.0",`, this currently only works for Laravel 9 or higher.

Please consider merging this PR so that I don't have to manage a fork just to make it work on Laravel 8.

It should be noted that Laravel Nova v4 explicitly supports both Laravel 8 & 9

Many thanks for your awesome calendar!