### PR TITLE
Fix for multi-day events that end on day 0

### DIFF
--- a/src/DataProvider/MonthCalendar.php
+++ b/src/DataProvider/MonthCalendar.php
@@ -202,7 +202,7 @@ abstract class MonthCalendar implements MonthDataProviderInterface
                     ($isFirstDayColumn
                         && $e->end() 
                         && $e->start()->isBefore($date) 
-                        && $e->end()->isAfter($date));
+                        && $e->end()->isAfter($date->clone()->subDay()));
         });
 
         // Sort events (as a heuristic, since CSS won't always match event order 


### PR DESCRIPTION
If you have a multi-day event that ends on a Monday, the calendar doesn't display the end of the event. This PR fixes that.