### PR TITLE
Laravel 12 and Laravel Nova 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "illuminate/support": "^8.0|^9.0|^10|^11",
-        "laravel/nova": "^4.2.4",
-        "wdelfuego/nova-datetime": "^1.0.1"
+        "illuminate/support": "^8.0|^9.0|^10|^11|^12",
+        "laravel/nova": "^4.2.4|^5.2.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/EventGenerator/MultiDay.php
+++ b/src/EventGenerator/MultiDay.php
@@ -20,8 +20,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Laravel\Nova\Resource as NovaResource;
 
-use Wdelfuego\Nova\DateTime\Filters\BeforeOrOnDate;
-use Wdelfuego\Nova\DateTime\Filters\AfterOrOnDate;
 use Wdelfuego\NovaCalendar\Event;
 
 class MultiDay extends NovaEventGenerator
@@ -39,15 +37,12 @@ class MultiDay extends NovaEventGenerator
         
         $dateAttributeStart = $toEventSpec[0];
         $dateAttributeEnd = $toEventSpec[1];
-        
-        $afterFilter = new AfterOrOnDate('', $dateAttributeEnd);
-        $beforeFilter = new BeforeOrOnDate('', $dateAttributeStart);
 
         // Since multi-day events are to be included, we have to query for
         // all models..
         $models = $eloquentModelClass::orderBy($dateAttributeStart);
         // a) that start before the end of the calendar, 
-        $models = $beforeFilter->modulateQuery($models, $rangeEnd);
+        $models = $models->whereDate($dateAttributeStart, '<=', $rangeEnd);
         // and that..
         $models = $models->where(function($query) use ($dateAttributeStart, $dateAttributeEnd, $rangeStart, $rangeEnd) {
             //    b) EITHER don't have an end date AND start on or after the calendar start

--- a/src/EventGenerator/SingleDay.php
+++ b/src/EventGenerator/SingleDay.php
@@ -20,8 +20,6 @@ use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Laravel\Nova\Resource as NovaResource;
 
-use Wdelfuego\Nova\DateTime\Filters\BeforeOrOnDate;
-use Wdelfuego\Nova\DateTime\Filters\AfterOrOnDate;
 use Wdelfuego\NovaCalendar\Event;
 
 class SingleDay extends NovaEventGenerator
@@ -36,15 +34,12 @@ class SingleDay extends NovaEventGenerator
         {
             throw new \Exception("Invalid toEventSpec: expected the name of a datetime attribute that starts the event as a single string");
         }
-        
-        $afterFilter = new AfterOrOnDate('', $toEventSpec);
-        $beforeFilter = new BeforeOrOnDate('', $toEventSpec);
 
         // Since these are single-day events by definition, we only query for the models
         // that have the date attribute within the current calendar range
         $models = $eloquentModelClass::orderBy($toEventSpec);
-        $models = $afterFilter->modulateQuery($models, $rangeStart);
-        $models = $beforeFilter->modulateQuery($models, $rangeEnd);
+        $models = $models->whereDate($toEventSpec, '>=', $rangeStart);
+        $models = $models->whereDate($toEventSpec, '<=', $rangeEnd);
 
         $out = [];
         foreach($models->cursor() as $model)


### PR DESCRIPTION
- added Laravel 12 support
- added Laravel Nova 5 support
- refactored to eliminate the dependency on the `wdelfuego/nova-datetime` package